### PR TITLE
fix(css markdown): *[id] is covered by header

### DIFF
--- a/source/css/style/_base/markdown.styl
+++ b/source/css/style/_base/markdown.styl
@@ -48,9 +48,11 @@ s
     box-sizing border-box
     font-smoothing antialiased
     osx-font-smoothing grayscale
-
-    &[id]
-        scroll-margin-top 54px
+    
+    if (hexo-config('navbar.sticky'))
+        @media screen and (min-width: 1080px)
+            &[id]
+                scroll-margin-top $header_height
 
 a
     color var(--main-color)

--- a/source/css/style/_base/markdown.styl
+++ b/source/css/style/_base/markdown.styl
@@ -49,6 +49,9 @@ s
     font-smoothing antialiased
     osx-font-smoothing grayscale
 
+    &[id]
+        scroll-margin-top 54px
+
 a
     color var(--main-color)
     cursor pointer


### PR DESCRIPTION
TOC 脚注 之类的在跳转时会被 header 遮挡