### PR TITLE
添加数据统计服务 Cloudflare Web Analytics

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -310,7 +310,7 @@ analytics:
   gtags_site_id:
   baidu_site_id: 
   cnzz_site_id: 
-  cloudflare_site_id: # 此处填写token
+  cloudflare_site_id: 
 
 
 

--- a/_config.yml
+++ b/_config.yml
@@ -310,6 +310,7 @@ analytics:
   gtags_site_id:
   baidu_site_id: 
   cnzz_site_id: 
+  cloudflare_site_id: # 此处填写token
 
 
 

--- a/layout/_plugins/analytics/cloudflare/source.ejs
+++ b/layout/_plugins/analytics/cloudflare/source.ejs
@@ -1,0 +1,5 @@
+<% if (theme.analytics && theme.analytics.cloudflare_site_id) { %>
+    <script defer src='https://static.cloudflareinsights.com/beacon.min.js'
+        data-cf-beacon='{"token": "<%= theme.analytics.cloudflare_site_id %>"}'></script>
+    </script>
+    <% } %>

--- a/layout/_plugins/analytics/index.ejs
+++ b/layout/_plugins/analytics/index.ejs
@@ -5,3 +5,5 @@
 <%- partial('./baidu/source') %>
 
 <%- partial('./cnzz/source') %>
+
+<%- partial('./cloudflare/source') %>


### PR DESCRIPTION
因为是第一次写JavaScript，所以是依照gtag和google的代码来写的，Cloudflare Web Analytics的脚本属性是```defer```，感觉和```async```有点相似所以就直接套用了。**Cloudflare Web Analytics会验证主机名（hostname）与添加JS代码段的网站是否匹配**。测试流程是依照`hexo-theme-cards/.github/workflows/test.yml`和`theme-cards-demo/.github/workflows/deploy.yml`来的，应该是可以使用的。

报错提示（本地报错出现这样的提示应该就是可用了）：

`Access to resource at 'https://cloudflareinsights.com/cdn-cgi/rum' from origin 'http://localhost:4000' has been blocked by CORS policy: Response to preflight request doesn't pass access control check: The 'Access-Control-Allow-Origin' header has a value 'http://localhost' that is not equal to the supplied origin.
`

Cloudflare Web Analytics的JavaScript 参考片段：

```javascript
<!-- Cloudflare Web Analytics --><script defer src='https://static.cloudflareinsights.com/beacon.min.js' data-cf-beacon='{"token": "xxxxxxxxxx"}'></script><!-- End Cloudflare Web Analytics -->
```

参考资料：

1. https://support.cloudflare.com/hc/en-us/articles/360052685432-Cloudflare-Web-Analytics
2. [脚本：async，defer (javascript.info)](https://zh.javascript.info/script-async-defer#defer)
3. https://dash.cloudflare.com/sign-up/web-analytics 