### PR TITLE
添加数据统计服务 Umami

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -311,8 +311,9 @@ analytics:
   baidu_site_id: 
   cnzz_site_id: 
   cloudflare_site_id: 
-  umami_site_id:
-  umami_site_url:
+  umami:
+    id:
+    url:
 
 
 

--- a/_config.yml
+++ b/_config.yml
@@ -311,6 +311,8 @@ analytics:
   baidu_site_id: 
   cnzz_site_id: 
   cloudflare_site_id: 
+  umami_site_id:
+  umami_site_url:
 
 
 

--- a/layout/_plugins/analytics/index.ejs
+++ b/layout/_plugins/analytics/index.ejs
@@ -7,3 +7,5 @@
 <%- partial('./cnzz/source') %>
 
 <%- partial('./cloudflare/source') %>
+
+<%- partial('./umami/source') %>

--- a/layout/_plugins/analytics/umami/source.ejs
+++ b/layout/_plugins/analytics/umami/source.ejs
@@ -1,0 +1,4 @@
+<% if (theme.analytics && theme.analytics.umami_site_id && theme.analytics.umami_site_url) { %>
+    <script async defer data-website-id="<%= theme.analytics.umami_site_id %>"
+        src="<%= theme.analytics.umami_site_url %>"></script>
+    <% } %>

--- a/layout/_plugins/analytics/umami/source.ejs
+++ b/layout/_plugins/analytics/umami/source.ejs
@@ -1,4 +1,4 @@
-<% if (theme.analytics && theme.analytics.umami_site_id && theme.analytics.umami_site_url) { %>
-    <script async defer data-website-id="<%= theme.analytics.umami_site_id %>"
-        src="<%= theme.analytics.umami_site_url %>"></script>
+<% if ( theme.analytics && theme.analytics.umami.id && theme.analytics.umami.url) { %>
+    <script async defer data-website-id="<%= theme.analytics.umami.id %>"
+        src="<%= theme.analytics.umami.url %>"></script>
     <% } %>


### PR DESCRIPTION
## Umami

Umami 是一个简单、易于使用、自托管的网站分析系统，没有第三方平台的接入。

Umami Live Demo地址: [https://umami.is/](https://umami.is/)
GitHub 项目地址: [https://github.com/mikecao/umami](https://github.com/mikecao/umami)
使用文档: [https://umami.is/docs](https://umami.is/docs/about)

这个PR已经在实际环境中测试通过。

------

## 其他的话

虽然我使用过很多网站数据分析系统，但奈何这些“追踪”系统的设计初衷都是围绕**如何提高广告转化率**，后台界面无比复杂，且这些系统背后的追踪域名早已上了各大Anti-AD项目的Block名单。Umami是我偶然在Github Topic上发现的一个项目，它非常简洁（这是我推荐它的原因之一），支持docker-compose部署，设置也只需要填写id和url就可以了。作者目前是一个月更新两次左右，项目已经是非常成熟的状态了。


## 相关截图
![image](https://user-images.githubusercontent.com/44700918/109384197-1bf9b580-7926-11eb-943a-af5a8f608d4a.png)
![image](https://user-images.githubusercontent.com/44700918/109384257-9296b300-7926-11eb-863f-c31fef8846e3.png)
