### PR TITLE
thumbnail 支持相对路径

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -155,6 +155,7 @@ meta:
   # 文章缩略图
   thumbnail: 
     enable: false
+    relative: false
     default:   # 默认缩略图，当页面 `thumbnail` 字段为空时 fallback 至此参数
 
   # 文章过时提醒

--- a/layout/_meta/thumbnail.ejs
+++ b/layout/_meta/thumbnail.ejs
@@ -1,7 +1,12 @@
 <% if (theme.meta.thumbnail.enable === true && (post.thumbnail || theme.meta.thumbnail.default)) { %>
+    <% let thumbnail = post.thumbnail %> 
+    <% if (theme.meta.thumbnail.relative === true && thumbnail.startsWith("/") === false) { %>
+        <% let postLink = url_for(post.link || post.path) %> 
+        <% thumbnail = url_for(postLink + "/" + thumbnail) %>
+    <% } %> 
     <% if (theme.lazyload && theme.lazyload.enable === true) { %>
-        <div class="post-thumbnail lazy" data-bg="<%= post.thumbnail || theme.meta.thumbnail.default %>"></div>
+        <div class="post-thumbnail lazy" data-bg="<%= thumbnail || theme.meta.thumbnail.default %>"></div>
     <% } else { %>
-        <div class="post-thumbnail" style="background-image: url('<%= post.thumbnail || theme.meta.thumbnail.default %>');"></div>
+        <div class="post-thumbnail" style="background-image: url('<%= thumbnail || theme.meta.thumbnail.default %>');"></div>
     <% } %>
 <% } %>


### PR DESCRIPTION
感谢作者制作的主题。

之前在 post 中的 thumbnail 会全部识别为绝对路径，对于启用了 [资源文件夹](https://hexo.io/zh-cn/docs/asset-folders) 的用户来说，想要将资源文件夹中的图片作为缩略图颇为不便。
所以修改为只要不以 "/" 开头的都为相对路径。但是应该有部分用户在使用中是直接配置的 `thumbnail: xxx.jpg` ，所以在主题配置文件中添加了配置默认关闭相对路径。