### PR TITLE
fix: move analytics script to head section

### DIFF
--- a/layout/_partial/head/index.ejs
+++ b/layout/_partial/head/index.ejs
@@ -1,6 +1,9 @@
 <head>
     <meta charset="utf-8">
 
+    <!-- 把 analytics 的代码放在 head 开始后 -->
+    <%- partial('_plugins/analytics/index') %>
+
     <% if (page.robots) { %>
         <meta name="robots" content="<%= page.robots %>">
     <% } %>

--- a/layout/_partial/scripts/index.ejs
+++ b/layout/_partial/scripts/index.ejs
@@ -1,7 +1,5 @@
 <%- partial('_plugins/lazyload/source') %> 
 
-<%- partial('_plugins/analytics/index') %> 
-
 <%- partial('_plugins/statistics/index', {position: 'script'}) %> 
 
 <%- partial('_plugins/fancybox/source') %> 

--- a/layout/_plugins/analytics/cloudflare/source.ejs
+++ b/layout/_plugins/analytics/cloudflare/source.ejs
@@ -1,5 +1,4 @@
 <% if (theme.analytics && theme.analytics.cloudflare_site_id) { %>
     <script defer src='https://static.cloudflareinsights.com/beacon.min.js'
         data-cf-beacon='{"token": "<%= theme.analytics.cloudflare_site_id %>"}'></script>
-    </script>
     <% } %>


### PR DESCRIPTION
使用Google Analytics和百度统计网站数据过程中，经过不同设备和网络反复测试，只有放在<head>标签下的跟踪代码才会启用数据收集功能